### PR TITLE
Feature/new thresh finder

### DIFF
--- a/qct-parse.py
+++ b/qct-parse.py
@@ -674,6 +674,8 @@ def main():
 	## Validate required arguments
 	if not args.i:
 		parser.error("the following arguments are required: -i/--input [path to QCTools report]")
+	if args.o and args.u:
+		parser.error("Both the -o and -u options were used. Cannot set threshold for both over and under, only one at a time.")
 	
 	##### Initialize variables and buffers ######
 	startObj = args.i.replace("\\","/")

--- a/qct-parse.py
+++ b/qct-parse.py
@@ -662,7 +662,7 @@ def main():
 	parser.add_argument('-buff','--buffSize',dest='buff',default=11, help="Size of the circular buffer. if user enters an even number it'll default to the next largest number to make it odd (default size 11)")
 	parser.add_argument('-te','--thumbExport',dest='te',action='store_true',default=False, help="export thumbnail")
 	parser.add_argument('-ted','--thumbExportDelay',dest='ted',default=9000, help="minimum frames between exported thumbs")
-	parser.add_argument('-tep','--thumbExportPath',dest='tep',default='', help="Path to thumb export. if ommitted, it uses the input basename")
+	parser.add_argument('-tep','--thumbExportPath',dest='tep',default='', help="Path to thumb export. if omitted, it uses the input basename")
 	parser.add_argument('-ds','--durationStart',dest='ds',default=0, help="the duration in seconds to start analysis")
 	parser.add_argument('-de','--durationEnd',dest='de',default=99999999, help="the duration in seconds to stop analysis")
 	parser.add_argument('-bd','--barsDetection',dest='bd',action ='store_true',default=False, help="turns Bar Detection on and off")
@@ -673,7 +673,7 @@ def main():
 	
 	## Validate required arguments
 	if not args.i:
-		parser.error("the following arguments are required: -i [path to QCTools report]")
+		parser.error("the following arguments are required: -i/--input [path to QCTools report]")
 	
 	##### Initialize variables and buffers ######
 	startObj = args.i.replace("\\","/")


### PR DESCRIPTION
Refactored analyzeIt and threshFinder functions to no longer have conditionals for -p/--profile vs -t/--tagname options. Arguments provided for -t and -o/-u flags (if found) are formatted to match profile dict, so tagname and thresholds can be parsed the same way for adhoc tags and profile. Added a parser error if -o and -u are used together. 